### PR TITLE
feat(workflow-templates): use OIDC creds

### DIFF
--- a/workflow-templates/build-and-push-arm64.properties.json
+++ b/workflow-templates/build-and-push-arm64.properties.json
@@ -1,5 +1,5 @@
 {
-  "name": "Crossbuild for ARM64 and Push to ECR Workflow",
+  "name": "Build and Push (arm64) to ECR Workflow",
   "description": "Builds a Docker image for arm64 compute from your Dockerfile and pushes it to ECR in the glgapp account",
   "filePatterns": "^Dockerfile"
 }

--- a/workflow-templates/build-and-push-arm64.yml
+++ b/workflow-templates/build-and-push-arm64.yml
@@ -1,5 +1,5 @@
 # vi:syntax=yaml
-name: Build ARM64 Image and Push toggp ECR
+name: Build ARM64 Image and Push to ECR
 on:
   # This provides a button in the actions tab to run this on demand
   workflow_dispatch:

--- a/workflow-templates/build-and-push-arm64.yml
+++ b/workflow-templates/build-and-push-arm64.yml
@@ -1,5 +1,5 @@
 # vi:syntax=yaml
-name: Build ARM64 Image and Push to glgapp ECR
+name: Build ARM64 Image and Push toggp ECR
 on:
   # This provides a button in the actions tab to run this on demand
   workflow_dispatch:
@@ -12,11 +12,27 @@ on:
       - "README.md"
 
 jobs:
-  build-and-push-glgapp-ecr:
+  build-and-push-ecr:
+    strategy:
+      matrix:
+        # If you need to push to multiple accounts, you can add them here
+        aws_account_ids: ["868468680417"] # glgapp account
+
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read 
+
     steps:
-      # Checks out the code from this repo
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+ 
+      - name: Setup ECR OIDC Credentials
+        id: aws-setup
+        uses: glg/setup-ecr-aws-oidc@main
+        with:
+          aws_account_id: ${{ matrix.aws_account_ids }}
 
       # This sets up qemu to build arm64 images on amd64 runners
       # This SHA is version 3.0.0 of the action
@@ -34,12 +50,10 @@ jobs:
       # Builds a docker image from ./dockerfile, and pushes it to our ECR repository
       - uses: glg/build-and-push@main
         with:
+          ecr_uri: ${{ steps.aws-setup.outputs.ecr_uri }}
           # This tells our action to build for arm64
           platform: linux/arm64
           # If you are pushing to a different account than glgapp, change these 3 lines.
-          ecr_uri: ${{secrets.GLGAPP_ECR_URI}}
-          access_key_id: ${{secrets.GLGAPP_ECR_AWS_ACCESS_KEY_ID}}
-          secret_access_key: ${{secrets.GLGAPP_ECR_AWS_SECRET_ACCESS_KEY}}
           # Uncomment if you are build you image in glgapp account and want to push the image to AWS China, it is only applicable for glgapp account.
           # sync_to_aws_china: true
           # Uncomment if you have private repo dependancies in your package.json

--- a/workflow-templates/build-and-push-x86-and-arm.yml
+++ b/workflow-templates/build-and-push-x86-and-arm.yml
@@ -12,19 +12,32 @@ on:
       - "README.md"
 
 jobs:
-  build-and-push:
+  build-and-push-ecr:
+    strategy:
+      matrix:
+        # If you need to push to multiple accounts, you can add them here
+        aws_account_ids: ["868468680417"] # glgapp account
+
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read 
+
     steps:
-      # Checks out the code from this repo
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+ 
+      - name: Setup ECR OIDC Credentials
+        id: aws-setup
+        uses: glg/setup-ecr-aws-oidc@main
+        with:
+          aws_account_id: ${{ matrix.aws_account_ids }}
 
       # Builds a docker image from ./dockerfile, and pushes it to our ECR repository
       - uses: glg/build-and-push@main
         with:
-          # If you are pushing to a different account than glgapp, change these 3 lines.
-          ecr_uri: ${{secrets.GLGAPP_ECR_URI}}
-          access_key_id: ${{secrets.GLGAPP_ECR_AWS_ACCESS_KEY_ID}}
-          secret_access_key: ${{secrets.GLGAPP_ECR_AWS_SECRET_ACCESS_KEY}}
+          ecr_uri: ${{ steps.aws-setup.outputs.ecr_uri }}
           # Uncomment if you are build you image in glgapp account and want to push the image to AWS China, it is only applicable for glgapp account.
           # sync_to_aws_china: true
           # Uncomment if you have private repo dependancies in your package.json
@@ -32,11 +45,27 @@ jobs:
           # Uncomment if you have private package dependancies in your package.json
           # github_packages_token: ${{ secrets.GH_PACKAGE_REGISTRY_READ_TOKEN }}
 
-  build-and-push-arm:
+  build-and-push-ecr-arm:
+    strategy:
+      matrix:
+        # If you need to push to multiple accounts, you can add them here
+        aws_account_ids: ["868468680417"] # glgapp account
+
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read 
+
     steps:
-      # Checks out the code from this repo
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+ 
+      - name: Setup ECR OIDC Credentials
+        id: aws-setup-arm
+        uses: glg/setup-ecr-aws-oidc@main
+        with:
+          aws_account_id: ${{ matrix.aws_account_ids }}
 
       # This sets up qemu to build arm64 images on amd64 runners
       # This SHA is version 3.0.0 of the action
@@ -54,14 +83,11 @@ jobs:
       # Builds a docker image from ./dockerfile, and pushes it to our ECR repository
       - uses: glg/build-and-push@main
         with:
-          # If you are pushing to a different account than glgapp, change these 3 lines.
-          ecr_uri: ${{secrets.GLGAPP_ECR_URI}}
-          access_key_id: ${{secrets.GLGAPP_ECR_AWS_ACCESS_KEY_ID}}
-          secret_access_key: ${{secrets.GLGAPP_ECR_AWS_SECRET_ACCESS_KEY}}
+          ecr_uri: ${{ steps.aws-setup-arm.outputs.ecr_uri }}
           # These are needed to be set for the arm64 builds
           platform: linux/arm64
-          image_tag: arm64
           # This is the tag-prefix that arm builds will have
+          image_tag: arm64
           # Uncomment if you are build you image in glgapp account and want to push the image to AWS China, it is only applicable for glgapp account.
           # sync_to_aws_china: true
           # Uncomment if you have private repo dependancies in your package.json

--- a/workflow-templates/build-and-push.yml
+++ b/workflow-templates/build-and-push.yml
@@ -1,5 +1,5 @@
 # vi:syntax=yaml
-name: Build Image and Push to glgapp ECR
+name: Build and Push to ECR
 on:
   # This provides a button in the actions tab to run this on demand
   workflow_dispatch:
@@ -13,19 +13,32 @@ on:
       - 'README.md'
 
 jobs:
-  build-and-push-glgapp-ecr:
+  build-and-push-ecr:
+    strategy:
+      matrix:
+        # If you need to push to multiple accounts, you can add them here
+        aws_account_ids: ["868468680417"] # glgapp account
+
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read 
+
     steps:
-      # Checks out the code from this repo
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+ 
+      - name: Setup ECR OIDC Credentials
+        id: aws-setup
+        uses: glg/setup-ecr-aws-oidc@main
+        with:
+          aws_account_id: ${{ matrix.aws_account_ids }}
 
       # Builds a docker image from ./dockerfile, and pushes it to our ECR repository
       - uses: glg/build-and-push@main
         with:
-          # If you are pushing to a different account than glgapp, change these 3 lines.
-          ecr_uri: ${{secrets.GLGAPP_ECR_URI}}
-          access_key_id: ${{secrets.GLGAPP_ECR_AWS_ACCESS_KEY_ID}}
-          secret_access_key: ${{secrets.GLGAPP_ECR_AWS_SECRET_ACCESS_KEY}}
+          ecr_uri: ${{ steps.aws-setup.outputs.ecr_uri }}
           # Uncomment if you are build you image in glgapp account and want to push the image to AWS China, it is only applicable for glgapp account.
           # sync_to_aws_china: true
           # Uncomment if you have private repo dependancies in your package.json


### PR DESCRIPTION
Update the `build-and-push` workflow templates to use the new OIDC process

- https://github.com/glg/sre-roadmap/issues/318
- closes: https://github.com/glg/sre-roadmap/issues/439

Tested in my test repo

<img width="1279" height="235" alt="image" src="https://github.com/user-attachments/assets/1fcb64cb-599d-48d5-8cbe-533e5ca57332" />

