### PR TITLE
chore(workflow-templates): update aws account matrix && bump qemu and buildx versions

### DIFF
--- a/workflow-templates/build-and-push-arm64.yml
+++ b/workflow-templates/build-and-push-arm64.yml
@@ -16,16 +16,15 @@ jobs:
     strategy:
       matrix:
         # To push to additional AWS accounts, uncomment the desired lines below.
-        aws_account_ids: [
-          "868468680417",  # glgapp
-        #   "160069906927",  # search
-        #   "677895703113",  # insights
-        #   "048313327362",  # conference-platform
-        #   "988857891049",  # prototype
-        #   "925358234994",  # gds-reverse-proxy-vault
-        #   "196017527820",  # infrastructure-management
-        #   "368307259700"   # ai-experiments
-        ]
+        aws_account_ids:
+          - "868468680417"  # glgapp
+          # - "160069906927"  # search
+          # - "677895703113"  # insights
+          # - "048313327362"  # conference-platform
+          # - "988857891049"  # prototype
+          # - "925358234994"  # gds-reverse-proxy-vault
+          # - "196017527820"  # infrastructure-management
+          # - "368307259700"  # ai-experiments
 
     runs-on: ubuntu-latest
     permissions:

--- a/workflow-templates/build-and-push-arm64.yml
+++ b/workflow-templates/build-and-push-arm64.yml
@@ -43,14 +43,14 @@ jobs:
           aws_account_id: ${{ matrix.aws_account_ids }}
 
       # This sets up qemu to build arm64 images on amd64 runners
-      # This SHA is version 3.0.0 of the action
-      - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
+      # This SHA is version v3.6.0 of the action
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
         with:
           platforms: linux/arm64
 
       # This sets buildx to assist in cross-architecture builds
-      # This SHA is version 3.0.0 of the action
-      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+      # This SHA is version v3.11.1 of the action
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
         with:
           install: true
           version: latest

--- a/workflow-templates/build-and-push-x86-and-arm.yml
+++ b/workflow-templates/build-and-push-x86-and-arm.yml
@@ -16,16 +16,15 @@ jobs:
     strategy:
       matrix:
         # To push to additional AWS accounts, uncomment the desired lines below.
-        aws_account_ids: [
-          "868468680417",  # glgapp
-        #   "160069906927",  # search
-        #   "677895703113",  # insights
-        #   "048313327362",  # conference-platform
-        #   "988857891049",  # prototype
-        #   "925358234994",  # gds-reverse-proxy-vault
-        #   "196017527820",  # infrastructure-management
-        #   "368307259700"   # ai-experiments
-        ]
+        aws_account_ids:
+          - "868468680417"  # glgapp
+          # - "160069906927"  # search
+          # - "677895703113"  # insights
+          # - "048313327362"  # conference-platform
+          # - "988857891049"  # prototype
+          # - "925358234994"  # gds-reverse-proxy-vault
+          # - "196017527820"  # infrastructure-management
+          # - "368307259700"  # ai-experiments
 
     runs-on: ubuntu-latest
     permissions:
@@ -58,16 +57,15 @@ jobs:
     strategy:
       matrix:
         # To push to additional AWS accounts, uncomment the desired lines below.
-        aws_account_ids: [
-          "868468680417",  # glgapp
-        #   "160069906927",  # search
-        #   "677895703113",  # insights
-        #   "048313327362",  # conference-platform
-        #   "988857891049",  # prototype
-        #   "925358234994",  # gds-reverse-proxy-vault
-        #   "196017527820",  # infrastructure-management
-        #   "368307259700"   # ai-experiments
-        ]
+        aws_account_ids:
+          - "868468680417"  # glgapp
+          # - "160069906927"  # search
+          # - "677895703113"  # insights
+          # - "048313327362"  # conference-platform
+          # - "988857891049"  # prototype
+          # - "925358234994"  # gds-reverse-proxy-vault
+          # - "196017527820"  # infrastructure-management
+          # - "368307259700"  # ai-experiments
 
     runs-on: ubuntu-latest
     permissions:

--- a/workflow-templates/build-and-push-x86-and-arm.yml
+++ b/workflow-templates/build-and-push-x86-and-arm.yml
@@ -84,14 +84,14 @@ jobs:
           aws_account_id: ${{ matrix.aws_account_ids }}
 
       # This sets up qemu to build arm64 images on amd64 runners
-      # This SHA is version 3.0.0 of the action
-      - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
+      # This SHA is version v3.6.0 of the action
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
         with:
           platforms: linux/arm64
 
       # This sets buildx to assist in cross-architecture builds
-      # This SHA is version 3.0.0 of the action
-      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+      # This SHA is version v3.11.1 of the action
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
         with:
           install: true
           version: latest

--- a/workflow-templates/build-and-push.yml
+++ b/workflow-templates/build-and-push.yml
@@ -17,16 +17,15 @@ jobs:
     strategy:
       matrix:
         # To push to additional AWS accounts, uncomment the desired lines below.
-        aws_account_ids: [
-          "868468680417",  # glgapp
-        #   "160069906927",  # search
-        #   "677895703113",  # insights
-        #   "048313327362",  # conference-platform
-        #   "988857891049",  # prototype
-        #   "925358234994",  # gds-reverse-proxy-vault
-        #   "196017527820",  # infrastructure-management
-        #   "368307259700"   # ai-experiments
-        ]
+        aws_account_ids:
+          - "868468680417"  # glgapp
+          # - "160069906927"  # search
+          # - "677895703113"  # insights
+          # - "048313327362"  # conference-platform
+          # - "988857891049"  # prototype
+          # - "925358234994"  # gds-reverse-proxy-vault
+          # - "196017527820"  # infrastructure-management
+          # - "368307259700"  # ai-experiments
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The map was causing YAML errors due to the comments, converting the aws_account_ids matrix to a block.

<img width="631" height="322" alt="image" src="https://github.com/user-attachments/assets/7648f92c-632c-4cea-a3a0-2587b5791d8e" />

Tested in my test repo - https://github.com/glg/mw-test/actions/runs/17123299354

Bump qemu and buildx versions to latest to fix cache errors

BEFORE

<img width="1481" height="259" alt="image" src="https://github.com/user-attachments/assets/a59507f2-e54e-4ef4-a480-d418b05f8fb6" />

AFTER

<img width="1822" height="833" alt="image" src="https://github.com/user-attachments/assets/a4336e84-c179-4f45-a580-fedcfec02e88" />



