### PR TITLE
chore(workflows): bump actions/checkout from v4 to v6

### DIFF
--- a/workflow-templates/build-and-push-arm64.yml
+++ b/workflow-templates/build-and-push-arm64.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
  
       - name: Setup ECR OIDC Credentials
         id: aws-setup

--- a/workflow-templates/build-and-push-x86-and-arm.yml
+++ b/workflow-templates/build-and-push-x86-and-arm.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
  
       - name: Setup ECR OIDC Credentials
         id: aws-setup
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
  
       - name: Setup ECR OIDC Credentials
         id: aws-setup-arm

--- a/workflow-templates/build-and-push.yml
+++ b/workflow-templates/build-and-push.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
  
       - name: Setup ECR OIDC Credentials
         id: aws-setup


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` from `v4` to `v6` in all three workflow templates: `build-and-push.yml`, `build-and-push-x86-and-arm.yml`, and `build-and-push-arm64.yml`

## Why

`actions/checkout@v4` runs on Node.js 20, which is deprecated on GitHub Actions runners. Actions will be forced onto Node.js 24 starting **June 2, 2026**, and Node.js 20 will be removed entirely on **September 16, 2026**. `actions/checkout@v6` (released 2026-01-09) runs on Node.js 24.

## Verification

Templates render correctly and use `actions/checkout@v6` in all steps.